### PR TITLE
feat: support bedtime notification

### DIFF
--- a/lib/model/alarm_settings.dart
+++ b/lib/model/alarm_settings.dart
@@ -51,6 +51,16 @@ class AlarmSettings {
   /// Stops the alarm on opened notification.
   final bool stopOnNotificationOpen;
 
+  /// Date and time when a notification will be triggered to notify the user
+  /// that it's time to go to bed.
+  final DateTime? bedtime;
+
+  /// Title of the notification to be shown when it's time for [bedtime].
+  final String? bedtimeNotificationTitle;
+
+  /// Body of the notification to be shown when it's time for [bedtime].
+  final String? bedtimeNotificationBody;
+
   /// Additional data to pass around.
   final Map<String, dynamic>? extra;
 
@@ -70,6 +80,9 @@ class AlarmSettings {
     hash = hash ^ (notificationBody?.hashCode ?? 0);
     hash = hash ^ enableNotificationOnKill.hashCode;
     hash = hash ^ stopOnNotificationOpen.hashCode;
+    hash = hash ^ (bedtime?.hashCode ?? 0);
+    hash = hash ^ (bedtimeNotificationTitle?.hashCode ?? 0);
+    hash = hash ^ (bedtimeNotificationBody?.hashCode ?? 0);
     hash = hash ^ (extra?.hashCode ?? 0);
     hash = hash & 0x3fffffff;
 
@@ -93,6 +106,9 @@ class AlarmSettings {
     this.notificationBody,
     this.enableNotificationOnKill = true,
     this.stopOnNotificationOpen = true,
+    this.bedtime,
+    this.bedtimeNotificationTitle,
+    this.bedtimeNotificationBody,
     this.extra,
   });
 
@@ -109,6 +125,11 @@ class AlarmSettings {
         notificationBody: json['notificationBody'] as String?,
         enableNotificationOnKill: json['enableNotificationOnKill'] as bool,
         stopOnNotificationOpen: json['stopOnNotificationOpen'] as bool,
+        bedtime: json['bedtime'] != null
+            ? DateTime.fromMicrosecondsSinceEpoch(json['bedtime'] as int)
+            : null,
+        bedtimeNotificationTitle: json['bedtimeNotificationTitle'] as String?,
+        bedtimeNotificationBody: json['bedtimeNotificationBody'] as String?,
         extra: json['extra'] as Map<String, dynamic>?,
       );
 
@@ -126,6 +147,9 @@ class AlarmSettings {
     String? notificationBody,
     bool? enableNotificationOnKill,
     bool? stopOnNotificationOpen,
+    DateTime? bedtime,
+    String? bedtimeNotificationTitle,
+    String? bedtimeNotificationBody,
     Map<String, dynamic>? extra,
   }) {
     return AlarmSettings(
@@ -142,6 +166,11 @@ class AlarmSettings {
           enableNotificationOnKill ?? this.enableNotificationOnKill,
       stopOnNotificationOpen:
           stopOnNotificationOpen ?? this.stopOnNotificationOpen,
+      bedtime: bedtime ?? this.bedtime,
+      bedtimeNotificationTitle:
+          bedtimeNotificationTitle ?? this.bedtimeNotificationTitle,
+      bedtimeNotificationBody:
+          bedtimeNotificationBody ?? this.bedtimeNotificationBody,
       extra: extra ?? this.extra,
     );
   }
@@ -159,6 +188,9 @@ class AlarmSettings {
         'notificationBody': notificationBody,
         'enableNotificationOnKill': enableNotificationOnKill,
         'stopOnNotificationOpen': stopOnNotificationOpen,
+        'bedtime': bedtime?.microsecondsSinceEpoch,
+        'bedtimeNotificationTitle': bedtimeNotificationTitle,
+        'bedtimeNotificationBody': bedtimeNotificationBody,
         'extra': extra,
       };
 
@@ -167,6 +199,9 @@ class AlarmSettings {
   String toString() {
     Map<String, dynamic> json = toJson();
     json['dateTime'] = DateTime.fromMicrosecondsSinceEpoch(json['dateTime']);
+    json['bedtime'] = json['bedtime'] != null
+        ? DateTime.fromMicrosecondsSinceEpoch(json['bedtime'])
+        : null;
 
     return "AlarmSettings: ${json.toString()}";
   }
@@ -188,5 +223,8 @@ class AlarmSettings {
           notificationBody == other.notificationBody &&
           enableNotificationOnKill == other.enableNotificationOnKill &&
           stopOnNotificationOpen == other.stopOnNotificationOpen &&
+          bedtime == other.bedtime &&
+          bedtimeNotificationTitle == other.bedtimeNotificationTitle &&
+          bedtimeNotificationBody == other.bedtimeNotificationBody &&
           mapEquals(extra, other.extra);
 }

--- a/lib/service/notification.dart
+++ b/lib/service/notification.dart
@@ -14,8 +14,27 @@ class AlarmNotification {
 
   final localNotif = FlutterLocalNotificationsPlugin();
 
-  /// Stream when notification is selected.
-  static final notificationStream = StreamController<AlarmSettings>();
+  /// Stream when the alarm notification is selected.
+  static final alarmNotificationStream = StreamController<AlarmSettings>();
+
+  /// Stream when the bedtime notification is selected.
+  static final bedtimeNotificationStream = StreamController<AlarmSettings>();
+
+  /// Checks if a notification launched the app and if so, triggers the
+  /// callback
+  static Future<bool> checkNotificationLaunchedApp() async {
+    final NotificationAppLaunchDetails? notificationAppLaunchDetails =
+        await instance.localNotif.getNotificationAppLaunchDetails();
+
+    final notificationResponse =
+        notificationAppLaunchDetails?.notificationResponse;
+
+    if (notificationResponse != null) {
+      onSelectNotification(notificationResponse);
+      return true;
+    }
+    return false;
+  }
 
   static Future<bool> get didNotificationLaunchedApp async {
     final NotificationAppLaunchDetails? notificationAppLaunchDetails =
@@ -24,6 +43,7 @@ class AlarmNotification {
       alarmPrint(
           '[NOTIFICATION] couln\'t find if app was launched by notification');
     }
+
     return notificationAppLaunchDetails?.didNotificationLaunchApp ?? false;
   }
 
@@ -47,30 +67,86 @@ class AlarmNotification {
 
     await localNotif.initialize(
       initializationSettings,
-      onDidReceiveBackgroundNotificationResponse: onSelectNotification,
+      onDidReceiveBackgroundNotificationResponse:
+          onSelectNotificationBackground,
       onDidReceiveNotificationResponse: onSelectNotification,
     );
     tz.initializeTimeZones();
   }
 
+  @pragma('vm:entry-point')
+  static onSelectNotificationBackground(
+          NotificationResponse notificationResponse) =>
+      onSelectNotification(notificationResponse);
+
   // Callback to stop the alarm when the notification is opened.
   static onSelectNotification(NotificationResponse notificationResponse) async {
+    alarmPrint(
+      '[ALARM_NOTIFICATION] notification selected. Payload: ${notificationResponse.payload}',
+    );
+    if (notificationResponse.payload != null) {
+      final alarmId = int.tryParse(notificationResponse.payload!);
+      onSelectBedtimeNotification(alarmId, notificationResponse);
+      return;
+    }
+
     final settings = Alarm.getAlarm(notificationResponse.id ?? 0);
     if (settings != null) {
-      notificationStream.add(settings);
+      alarmNotificationStream.add(settings);
     }
 
     await stopAlarm(notificationResponse.id);
   }
 
+  static onSelectBedtimeNotification(
+      int? alarmId, NotificationResponse notificationResponse) async {
+    if (alarmId == null) {
+      return;
+    }
+
+    final settings = Alarm.getAlarm(alarmId);
+    if (settings != null) {
+      bedtimeNotificationStream.add(settings);
+    }
+  }
+
   // Callback to stop the alarm when the notification is opened for iOS versions older than 10.
   static onSelectNotificationOldIOS(
-    int? id,
-    String? _,
-    String? __,
-    String? ___,
-  ) async =>
-      await stopAlarm(id);
+    int id,
+    String? title,
+    String? body,
+    String? payload,
+  ) async {
+    if (payload != null) {
+      final alarmId = int.tryParse(payload);
+      onSelectBedtimeNotificationOldIOS(alarmId, id, title, body, payload);
+      return;
+    }
+
+    final settings = Alarm.getAlarm(id);
+    if (settings != null) {
+      alarmNotificationStream.add(settings);
+    }
+
+    await stopAlarm(id);
+  }
+
+  static onSelectBedtimeNotificationOldIOS(
+    int? alarmId,
+    int id,
+    String? title,
+    String? body,
+    String? payload,
+  ) async {
+    if (alarmId == null) {
+      return;
+    }
+
+    final settings = Alarm.getAlarm(alarmId);
+    if (settings != null) {
+      bedtimeNotificationStream.add(settings);
+    }
+  }
 
   /// Stops the alarm.
   static Future<void> stopAlarm(int? id) async {
@@ -102,54 +178,77 @@ class AlarmNotification {
     return result ?? true;
   }
 
-  tz.TZDateTime nextInstanceOfTime(DateTime dateTime) {
-    final now = DateTime.now();
+  /// Shows notification permission request. May throw.
+  Future<bool> requestPermissionUnguarded() async {
+    final result = defaultTargetPlatform == TargetPlatform.android
+        ? await localNotif
+            .resolvePlatformSpecificImplementation<
+                AndroidFlutterLocalNotificationsPlugin>()
+            ?.requestPermission()
+        : await localNotif
+            .resolvePlatformSpecificImplementation<
+                IOSFlutterLocalNotificationsPlugin>()
+            ?.requestPermissions(alert: true, badge: true, sound: true);
+    return result ?? false;
+  }
 
-    if (dateTime.isBefore(now)) {
+  tz.TZDateTime nextInstanceOfTime(
+    DateTime dateTime, [
+    DateTime? nowAtStartup,
+  ]) {
+    nowAtStartup ??= DateTime.now();
+    if (dateTime.isBefore(nowAtStartup)) {
       dateTime = dateTime.add(const Duration(days: 1));
+    } else if (dateTime.isBefore(DateTime.now())) {
+      // Processing took longer than expected, trigger the notification now
+      dateTime = DateTime.now().add(const Duration(seconds: 1));
     }
 
     return tz.TZDateTime.from(dateTime, tz.local);
   }
 
   /// Schedules notification at the given [dateTime].
-  Future<void> scheduleAlarmNotif({
+  static Future<void> scheduleNotification({
     required int id,
     required DateTime dateTime,
     required String title,
     required String body,
+    bool playSound = false,
+    bool enableLights = false,
+    int? alarmId,
+    DateTime? nowAtStartup,
   }) async {
-    const iOSPlatformChannelSpecifics = DarwinNotificationDetails(
+    final iOSPlatformChannelSpecifics = DarwinNotificationDetails(
       presentAlert: false,
       presentBadge: false,
-      presentSound: false,
+      presentSound: playSound,
     );
 
-    const androidPlatformChannelSpecifics = AndroidNotificationDetails(
+    final androidPlatformChannelSpecifics = AndroidNotificationDetails(
       'alarm',
       'alarm_plugin',
       channelDescription: 'Alarm plugin',
       importance: Importance.max,
       priority: Priority.max,
-      playSound: false,
-      enableLights: true,
+      playSound: playSound,
+      enableLights: enableLights,
     );
 
-    const platformChannelSpecifics = NotificationDetails(
+    final platformChannelSpecifics = NotificationDetails(
       android: androidPlatformChannelSpecifics,
       iOS: iOSPlatformChannelSpecifics,
     );
 
-    final zdt = nextInstanceOfTime(dateTime);
+    final zdt = instance.nextInstanceOfTime(dateTime, nowAtStartup);
 
-    final hasPermission = await requestPermission();
+    final hasPermission = await instance.requestPermission();
     if (!hasPermission) {
       alarmPrint('Notification permission not granted');
       return;
     }
 
     try {
-      await localNotif.zonedSchedule(
+      await instance.localNotif.zonedSchedule(
         id,
         title,
         body,
@@ -158,6 +257,7 @@ class AlarmNotification {
         androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
         uiLocalNotificationDateInterpretation:
             UILocalNotificationDateInterpretation.absoluteTime,
+        payload: alarmId?.toString(),
       );
       alarmPrint(
         'Notification with id $id scheduled successfuly at $zdt (GMT - Zulu time)',

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,0 +1,18 @@
+/// FNV-1a 32bit hash algorithm optimized for Dart Strings
+int fastHash(String input) {
+  const int prime = 0x01000193; // 16777619
+  int hash = 0x811c9dc5; // 2166136261
+
+  for (int i = 0; i < input.length; i++) {
+    hash ^= input.codeUnitAt(i);
+    hash *= prime;
+    hash &= 0xFFFFFFFF; // Ensure it stays a 32-bit number
+  }
+
+  // Sign-extend to 32-bit signed integer
+  if ((hash & 0x80000000) != 0) {
+    hash = hash - 0x100000000;
+  }
+
+  return hash;
+}


### PR DESCRIPTION
**Summary of known issues**
1. When bedtime notification triggers and the user opens the app via the app icon (not by clicking on the notification), the falling asleep sleep plan phase doesn't start automatically.
2. Sometimes, opening the app via the bedtime notification will not start the falling asleep sleep plan phase*.

*This was tested on an Android simulator. At random, the notification automatically wakes up the app - without any user interaction. This throws off many assumptions this library is making. Sometimes, it took 10 times to force quit the app in order to reproduce this behavior. Even though I added some hacks to ensure the bedtime notification is displayed, the notification callback is still not invoked which prevents the app from starting the sleep plan.


Note: this library always cancels alarms/notifications and reschedules them when it loads. The main reason for this is iOS and how its scheduling works only for foreground apps. This worked ok-ish for alarm+notification that trigger at the same time. However with the newly added bedtime notification, we only rely on the notification's callback mechanism which now we know is fragile.